### PR TITLE
symfony 3 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=5.4.0",
         "kriswallsmith/buzz": "~0.7",
-        "symfony/event-dispatcher": "~2.0",
+        "symfony/event-dispatcher": "~2.0|~3.0",
         "messagebird/php-rest-api": "~1.1"
     },
     "require-dev": {


### PR DESCRIPTION
Allow version 3.0 of symfony/event-dispatcher.