### PR TITLE
Replace Buzz with Guzzle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - hhvm

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Xi SMS
 =======
 
-SMS library for PHP 5.3+.
+SMS library for PHP 5.5+.
 
 Abstracts away the gateways. Just send'n go!
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "xi/sms",
     "type": "library",
-    "description": "Short messaging for PHP 5.3",
+    "description": "Short messaging for PHP 5.5",
     "keywords": ["SMS"],
     "homepage": "http://github.com/xi-project/xi-sms",
     "license": "BSD",
@@ -14,8 +14,8 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
-        "guzzlehttp/guzzle": "~6.1",
+        "php": ">=5.5.0",
+        "guzzlehttp/guzzle": "~6.0",
         "symfony/event-dispatcher": "~2.0|~3.0",
         "messagebird/php-rest-api": "~1.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "kriswallsmith/buzz": "~0.7",
+        "guzzlehttp/guzzle": "~6.1",
         "symfony/event-dispatcher": "~2.0|~3.0",
         "messagebird/php-rest-api": "~1.1"
     },
@@ -25,7 +25,8 @@
     },
     "autoload": {
         "psr-4": {
-            "Xi\\Sms\\": "library/Xi/Sms/"
+            "Xi\\Sms\\": "library/Xi/Sms/",
+            "Xi\\Sms\\Tests\\": "tests/Xi/Sms/Tests/"
         }
     },
     "minimum-stability": "stable"

--- a/library/Xi/Sms/Filter/NumberLimitingFilter.php
+++ b/library/Xi/Sms/Filter/NumberLimitingFilter.php
@@ -19,18 +19,18 @@ class NumberLimitingFilter implements FilterInterface
     /**
      * @var array
      */
-    private $whitelisted = array();
+    private $whitelisted = [];
 
     /**
      * @var array
      */
-    private $blacklisted = array();
+    private $blacklisted = [];
 
     /**
      * @param array $whitelisted An array of whitelist regexes
      * @param array $blacklisted An array of blacklist regexes
      */
-    public function __construct($whitelisted = array(), $blacklisted = array())
+    public function __construct(array $whitelisted = [], array $blacklisted = [])
     {
         $this->whitelisted = $whitelisted;
         $this->blacklisted = $blacklisted;
@@ -44,11 +44,11 @@ class NumberLimitingFilter implements FilterInterface
         $to = $message->getTo();
 
         if ($this->whitelisted) {
-            $to = array_filter($to, array($this, 'handleWhitelisted'));
+            $to = array_filter($to, [$this, 'handleWhitelisted']);
         }
 
         if ($this->blacklisted) {
-            $to = array_filter($to, array($this, 'handleBlacklisted'));
+            $to = array_filter($to, [$this, 'handleBlacklisted']);
         }
         return (bool) $to;
     }

--- a/library/Xi/Sms/Gateway/BaseHttpRequestGateway.php
+++ b/library/Xi/Sms/Gateway/BaseHttpRequestGateway.php
@@ -9,8 +9,9 @@
 
 namespace Xi\Sms\Gateway;
 
-use Buzz\Browser;
-use Buzz\Client\Curl;
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\RequestOptions;
 
 /**
  * Convenience class for http sending gateways
@@ -18,25 +19,27 @@ use Buzz\Client\Curl;
 abstract class BaseHttpRequestGateway Implements GatewayInterface
 {
     /**
-     * @var Browser
+     * @var ClientInterface
      */
     private $client;
 
     /**
-     * @param Browser $browser
+     * @param ClientInterface $client
      */
-    public function setClient(Browser $browser)
+    public function setClient(ClientInterface $client)
     {
-        $this->client = $browser;
+        $this->client = $client;
     }
 
     /**
-     * @return Browser
+     * @return ClientInterface
      */
     public function getClient()
     {
         if (!$this->client) {
-            $this->client = new Browser(new Curl());
+            $this->client = new Client(array(
+                RequestOptions::HTTP_ERRORS => false
+            ));
         }
         return $this->client;
     }

--- a/library/Xi/Sms/Gateway/BaseHttpRequestGateway.php
+++ b/library/Xi/Sms/Gateway/BaseHttpRequestGateway.php
@@ -37,9 +37,9 @@ abstract class BaseHttpRequestGateway Implements GatewayInterface
     public function getClient()
     {
         if (!$this->client) {
-            $this->client = new Client(array(
+            $this->client = new Client([
                 RequestOptions::HTTP_ERRORS => false
-            ));
+            ]);
         }
         return $this->client;
     }

--- a/library/Xi/Sms/Gateway/ClickatellGateway.php
+++ b/library/Xi/Sms/Gateway/ClickatellGateway.php
@@ -57,7 +57,7 @@ class ClickatellGateway extends BaseHttpRequestGateway
         foreach ($message->getTo() as $to) {
             $url = "{$this->endpoint}/http/sendmsg?api_id={$this->apiKey}&user={$this->user}" .
                 "&password={$this->password}&to={$to}&text={$body}&from={$from}";
-            $this->getClient()->post($url, array());
+            $this->getClient()->post($url);
         }
         return true;
     }

--- a/library/Xi/Sms/Gateway/InfobipGateway.php
+++ b/library/Xi/Sms/Gateway/InfobipGateway.php
@@ -95,7 +95,9 @@ class InfobipGateway extends BaseHttpRequestGateway
 
         $requestBody = 'XML=' . preg_replace('/<\?xml.*\?>\n?/', '', $writer->outputMemory());
 
-        $this->getClient()->post($this->endpoint . '/v3/sendsms/xml', array(), $requestBody);
+        $this->getClient()->post($this->endpoint . '/v3/sendsms/xml', array(
+            'body' => $requestBody
+        ));
 
         return true;
     }

--- a/library/Xi/Sms/Gateway/IpxGateway.php
+++ b/library/Xi/Sms/Gateway/IpxGateway.php
@@ -103,7 +103,7 @@ class IpxGateway implements GatewayInterface
             //create soap client while setting response timeout to 10 minutes
             $this->client = new \SoapClient(
                 $this->wsdlUrl,
-                array('default_socket_timeout' => $this->timeout)
+                ['default_socket_timeout' => $this->timeout]
             );
         }
 
@@ -120,7 +120,7 @@ class IpxGateway implements GatewayInterface
      *
      * @return array
      */
-    protected function getParams($from, $to, $body, $params = array())
+    protected function getParams($from, $to, $body, array $params = [])
     {
         $correlationId = microtime(true);
         $originatingAddress = $from; //If MSISDN
@@ -134,7 +134,7 @@ class IpxGateway implements GatewayInterface
         }
 
         return array_merge(
-            array(
+            [
                 'correlationId' => $correlationId,
                 'originatingAddress' => $originatingAddress,
                 'originatorTON' => $originatorTON,
@@ -156,7 +156,7 @@ class IpxGateway implements GatewayInterface
                 'campaignName' => '#NULL#',
                 'username' => $this->username,
                 'password' => $this->password
-            ),
+            ],
             $params
         );
     }
@@ -194,12 +194,12 @@ class IpxGateway implements GatewayInterface
             foreach($parts as $index => $body) {
                 $params = array('userDataHeader' => sprintf('0500030F%02d%02d', $messageCount, $index+1));
                 $params = $this->getParams($from, $to, $body, $params);
-                $result = $client->__soapCall('send', array('request' => $params));
+                $result = $client->__soapCall('send', ['request' => $params]);
             }
         }
         else {
             $params = $this->getParams($from, $to, $body);
-            $result = $client->__soapCall('send', array('request' => $params));
+            $result = $client->__soapCall('send', ['request' => $params]);
         }
 
 

--- a/library/Xi/Sms/Gateway/Legacy/MessageBirdGateway.php
+++ b/library/Xi/Sms/Gateway/Legacy/MessageBirdGateway.php
@@ -65,7 +65,7 @@ class MessageBirdGateway extends BaseHttpRequestGateway
                 '&recipients=' . urlencode($to) .
                 '&type=' . urlencode($this->type) .
                 '&message=' . $body;
-            $ret = $this->getClient()->post($url, array());
+            $ret = $this->getClient()->post($url);
         }
 
         return true;

--- a/library/Xi/Sms/Gateway/MockGateway.php
+++ b/library/Xi/Sms/Gateway/MockGateway.php
@@ -19,7 +19,7 @@ class MockGateway implements GatewayInterface
     /**
      * @var array
      */
-    private $sentMessages = array();
+    private $sentMessages = [];
 
     public function send(SmsMessage $message)
     {

--- a/library/Xi/Sms/Gateway/PixieGateway.php
+++ b/library/Xi/Sms/Gateway/PixieGateway.php
@@ -9,6 +9,7 @@
 
 namespace Xi\Sms\Gateway;
 
+use Psr\Http\Message\ResponseInterface;
 use Xi\Sms\SmsMessage;
 use Xi\Sms\RuntimeException;
 
@@ -71,7 +72,7 @@ class PixieGateway extends BaseHttpRequestGateway
     public function sendOrThrowException(SmsMessage $message)
     {
         $url = $this->generateUrl($message);
-        $response = $this->getClient()->get($url, array());
+        $response = $this->getClient()->get($url);
         $result = $this->parseResponse($response);
         if ($result === true)
         {
@@ -104,13 +105,13 @@ class PixieGateway extends BaseHttpRequestGateway
     /**
      * Parse response from the server
      *
-     * @param \Buzz\Message\Response $response
+     * @param ResponseInterface $response
      *
      * @return mixed Returns boolean true for success, or RuntimeException for errors
      */
-    private function parseResponse(\Buzz\Message\Response $response)
+    private function parseResponse(ResponseInterface $response)
     {
-        $content = $response->getContent();
+        $content = $response->getBody();
 
         $response = new \DOMDocument();
         $result = @$response->loadXml($content);

--- a/library/Xi/Sms/Gateway/SmskaufenGateway.php
+++ b/library/Xi/Sms/Gateway/SmskaufenGateway.php
@@ -18,22 +18,22 @@ use Xi\Sms\RuntimeException;
 
 class SmskaufenGateway extends BaseHttpRequestGateway {
 
-	protected $_errorCodes = array(
+	protected $_errorCodes = [
 		'111' => 'IP blocked',
 		'112' => 'Wrong credentials (login/pw/apikey)',
 		'122' => 'Text is empty',
 		'123' => 'Recipient is empty',
 		'140' => 'No credit'
-	);
+	];
 
-	protected $settings = array(
+	protected $settings = [
 		'username' => '',
 		'password' => '',
 		'api_http' => 'http://www.smskaufen.com/sms/gateway/',
 		'api_https' => 'https://www.smskaufen.com/sms/gateway/',
 		'gateway' => 13,
 		'https' => false,
-	);
+	];
 
 	public function getBaseUrl() {
 		if ($this->settings['https']) {
@@ -46,7 +46,7 @@ class SmskaufenGateway extends BaseHttpRequestGateway {
 	 * @param array $settings
 	 * @throws RuntimeException Exception.
 	 */
-	public function __construct($settings = array()) {
+	public function __construct(array $settings = []) {
 		$this->settings = array_merge($this->settings, $settings);
 
 		if (empty($this->settings['username']) || empty($this->settings['password'])) {
@@ -72,34 +72,34 @@ class SmskaufenGateway extends BaseHttpRequestGateway {
 		if (empty($text)) {
 			return false;
 		}
-		if (strlen($text) > 160 && !in_array($this->settings['gateway'], array(2,3,4,8))) {
+		if (strlen($text) > 160 && !in_array($this->settings['gateway'], [2,3,4,8])) {
 			throw new RuntimeException('Only gateways 2,3,4,8 allow sending messages with more than 160 chars.');
 		}
 
 		$numbers = (array) $to;
-		$params = array(
+		$params = [
 			'id' => $this->settings['username'],
 			'pw' => $this->settings['password'],
 			'type' => $this->settings['gateway'],
 			'text' => $text,
 			'empfaenger' => implode(';', $numbers),
 			'absender' => $from,
-		);
+		];
 
 		if (count($numbers) > 1) {
 			$params['massen'] = 1;
 			$params['termin'] = date('d.m.Y-00:01', strtotime("-1 day")); # past => immediately
 		}
 
-		if (!empty($params['massen']) && !in_array($this->settings['gateway'], array(2,3,4,8))) {
+		if (!empty($params['massen']) && !in_array($this->settings['gateway'], [2,3,4,8])) {
 			throw new RuntimeException('Only gateways 2,3,4,8 allow mass sending');
 		}
 
 		$res = $this->getClient()->get(
 			$this->getBaseUrl() . 'sms.php?'.http_build_query($params),
-			array(
-				RequestOptions::HEADERS => array('Content-type' => 'application/x-www-form-urlencoded')
-			)
+			[
+				RequestOptions::HEADERS => ['Content-type' => 'application/x-www-form-urlencoded']
+			]
 		);
 
 		if ($res->getStatusCode() != 200) {

--- a/library/Xi/Sms/SmsMessage.php
+++ b/library/Xi/Sms/SmsMessage.php
@@ -27,7 +27,7 @@ class SmsMessage
     /**
      * @var array
      */
-    private $to = array();
+    private $to = [];
 
     /**
      * @param string $body

--- a/library/Xi/Sms/SmsService.php
+++ b/library/Xi/Sms/SmsService.php
@@ -27,7 +27,7 @@ class SmsService
     /**
      * @var FilterInterface[]
      */
-    private $filters = array();
+    private $filters = [];
 
     /**
      * @param GatewayInterface $gateway

--- a/tests/Xi/Sms/Tests/Filter/NumberLimitingFilterTest.php
+++ b/tests/Xi/Sms/Tests/Filter/NumberLimitingFilterTest.php
@@ -23,7 +23,7 @@ class NumberLimitingFilterTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldNotAcceptIfNoReceiversAreLeft()
     {
-        $filter = new NumberLimitingFilter(array(), array('#^358503028030$#'));
+        $filter = new NumberLimitingFilter([], ['#^358503028030$#']);
         $message = new SmsMessage('Body moving', 'BodyMover', '358503028030');
         $ret = $filter->accept($message);
         $this->assertFalse($ret);
@@ -36,8 +36,8 @@ class NumberLimitingFilterTest extends \PHPUnit_Framework_TestCase
     public function onlyTheStrongestShouldRemainAfterWhitelistingAndBlacklisting()
     {
         $filter = new NumberLimitingFilter(
-            array('#^358#'),
-            array('#^3585030280(30|31)$#', '#666$#')
+            ['#^358#'],
+            ['#^3585030280(30|31)$#', '#666$#']
         );
 
         $message = new SmsMessage('Body moving', 'BodyMover', '358503028031');

--- a/tests/Xi/Sms/Tests/Gateway/BaseHttpRequestGatewayTest.php
+++ b/tests/Xi/Sms/Tests/Gateway/BaseHttpRequestGatewayTest.php
@@ -14,7 +14,7 @@ class BaseHttpRequestGatewayTest extends \PHPUnit_Framework_TestCase
             ->getMockForAbstractClass();
 
         $client = $adapter->getClient();
-        $this->assertInstanceOf('Buzz\Browser', $client);
+        $this->assertInstanceOf('GuzzleHttp\Client', $client);
     }
 
     /**
@@ -26,7 +26,7 @@ class BaseHttpRequestGatewayTest extends \PHPUnit_Framework_TestCase
             ->getMockBuilder('Xi\Sms\Gateway\BaseHttpRequestGateway')
             ->getMockForAbstractClass();
 
-        $client = $this->getMockBuilder('Buzz\Browser')->disableOriginalConstructor()->getMock();
+        $client = $this->getMockBuilder('GuzzleHttp\ClientInterface')->disableOriginalConstructor()->getMock();
 
         $adapter->setClient($client);
 

--- a/tests/Xi/Sms/Tests/Gateway/ClickatellGatewayTest.php
+++ b/tests/Xi/Sms/Tests/Gateway/ClickatellGatewayTest.php
@@ -2,33 +2,26 @@
 
 namespace Xi\Sms\Tests\Gateway;
 
+use GuzzleHttp\Psr7\Response;
 use Xi\Sms\Gateway\ClickatellGateway;
+use Xi\Sms\SmsMessage;
 
 class ClickatellGatewayTest extends \PHPUnit_Framework_TestCase
 {
+
+    use HttpRequestGatewayTestTrait;
+
     /**
      * @test
      */
     public function sendsRequest()
     {
+        $client = $this->createMockClient($historyContainer);
+
         $gateway = new ClickatellGateway('lussavain', 'lussuta', 'tussia', 'http://api.dr-kobros.com');
+        $gateway->setClient($client);
 
-        $browser = $this->getMockBuilder('Buzz\Browser')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $gateway->setClient($browser);
-
-        $browser
-            ->expects($this->once())
-            ->method('post')
-            ->with(
-                'http://api.dr-kobros.com/http/sendmsg?api_id=lussavain&user=lussuta&password=' .
-                'tussia&to=358503028030&text=Pekkis+tassa+lussuttaa.&from=358503028030',
-                array()
-            );
-
-        $message = new \Xi\Sms\SmsMessage(
+        $message = new SmsMessage(
             'Pekkis tassa lussuttaa.',
             '358503028030',
             '358503028030'
@@ -36,5 +29,47 @@ class ClickatellGatewayTest extends \PHPUnit_Framework_TestCase
 
         $ret = $gateway->send($message);
         $this->assertTrue($ret);
+
+        $this->assertCount(1, $historyContainer);
+        $transaction = $historyContainer[0];
+        $expectedUri = 'http://api.dr-kobros.com/http/sendmsg?api_id=lussavain&user=lussuta&password=' .
+                       'tussia&to=358503028030&text=Pekkis+tassa+lussuttaa.&from=358503028030';
+        $this->assertSame('POST', $transaction['request']->getMethod());
+        $this->assertSame($expectedUri, (string) $transaction['request']->getUri());
     }
+
+    /**
+     * @test
+     */
+    public function sendsMultipleRequests()
+    {
+        $client = $this->createMockClient($historyContainer, array(
+            new Response(200),
+            new Response(200)
+        ));
+
+        $gateway = new ClickatellGateway('lussavain', 'lussuta', 'tussia', 'http://api.dr-kobros.com');
+        $gateway->setClient($client);
+
+        $message = new SmsMessage(
+            'Pekkis tassa lussuttaa.',
+            '358503028030',
+            array('358503028030', '358441234567')
+        );
+
+        $ret = $gateway->send($message);
+        $this->assertTrue($ret);
+
+        $this->assertCount(2, $historyContainer);
+        $transaction = $historyContainer[0];
+        $expectedUri = 'http://api.dr-kobros.com/http/sendmsg?api_id=lussavain&user=lussuta&password=' .
+                       'tussia&to=358503028030&text=Pekkis+tassa+lussuttaa.&from=358503028030';
+        $this->assertSame($expectedUri, (string) $transaction['request']->getUri());
+
+        $transaction = $historyContainer[1];
+        $expectedUri = 'http://api.dr-kobros.com/http/sendmsg?api_id=lussavain&user=lussuta&password=' .
+                       'tussia&to=358441234567&text=Pekkis+tassa+lussuttaa.&from=358503028030';
+        $this->assertSame($expectedUri, (string) $transaction['request']->getUri());
+    }
+
 }

--- a/tests/Xi/Sms/Tests/Gateway/ClickatellGatewayTest.php
+++ b/tests/Xi/Sms/Tests/Gateway/ClickatellGatewayTest.php
@@ -43,10 +43,10 @@ class ClickatellGatewayTest extends \PHPUnit_Framework_TestCase
      */
     public function sendsMultipleRequests()
     {
-        $client = $this->createMockClient($historyContainer, array(
+        $client = $this->createMockClient($historyContainer, [
             new Response(200),
             new Response(200)
-        ));
+        ]);
 
         $gateway = new ClickatellGateway('lussavain', 'lussuta', 'tussia', 'http://api.dr-kobros.com');
         $gateway->setClient($client);
@@ -54,7 +54,7 @@ class ClickatellGatewayTest extends \PHPUnit_Framework_TestCase
         $message = new SmsMessage(
             'Pekkis tassa lussuttaa.',
             '358503028030',
-            array('358503028030', '358441234567')
+            ['358503028030', '358441234567']
         );
 
         $ret = $gateway->send($message);

--- a/tests/Xi/Sms/Tests/Gateway/HttpRequestGatewayTestTrait.php
+++ b/tests/Xi/Sms/Tests/Gateway/HttpRequestGatewayTestTrait.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Xi\Sms\Tests\Gateway;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\RequestOptions;
+
+trait HttpRequestGatewayTestTrait
+{
+
+    /**
+     * Creates Guzzle client with mock handler.
+     * @param  array   &$historyContainer Pointer to variable where request history can be stored
+     * @param  mixed   $response          Response object or array of responses for requests, defaults to one HTTP 200 response
+     * @return Client
+     */
+    public function createMockClient(&$historyContainer = array(), $response = null)
+    {
+        if ($response instanceof Response) {
+            $response = array($response);
+        } elseif (is_array($response) === false || empty($response)) {
+            $response = array(new Response(200));
+        }
+
+        // Create a mock and queue one response
+        $mock = new MockHandler($response);
+
+        // History container can be used to inspect sent request
+        $historyContainer = array();
+        $history = Middleware::history($historyContainer);
+
+        $stack = HandlerStack::create($mock);
+        $stack->push($history);
+        $client = new Client(array(
+            'handler' => $stack,
+            RequestOptions::HTTP_ERRORS => false
+        ));
+
+        return $client;
+    }
+
+}

--- a/tests/Xi/Sms/Tests/Gateway/HttpRequestGatewayTestTrait.php
+++ b/tests/Xi/Sms/Tests/Gateway/HttpRequestGatewayTestTrait.php
@@ -15,30 +15,30 @@ trait HttpRequestGatewayTestTrait
     /**
      * Creates Guzzle client with mock handler.
      * @param  array   &$historyContainer Pointer to variable where request history can be stored
-     * @param  mixed   $response          Response object or array of responses for requests, defaults to one HTTP 200 response
+     * @param  array|Response|null $response    Response object or array of responses for requests, defaults to one HTTP 200 response
      * @return Client
      */
-    public function createMockClient(&$historyContainer = array(), $response = null)
+    public function createMockClient(&$historyContainer = [], $response = null)
     {
         if ($response instanceof Response) {
-            $response = array($response);
+            $response = [$response];
         } elseif (is_array($response) === false || empty($response)) {
-            $response = array(new Response(200));
+            $response = [new Response(200)];
         }
 
         // Create a mock and queue one response
         $mock = new MockHandler($response);
 
         // History container can be used to inspect sent request
-        $historyContainer = array();
+        $historyContainer = [];
         $history = Middleware::history($historyContainer);
 
         $stack = HandlerStack::create($mock);
         $stack->push($history);
-        $client = new Client(array(
+        $client = new Client([
             'handler' => $stack,
             RequestOptions::HTTP_ERRORS => false
-        ));
+        ]);
 
         return $client;
     }

--- a/tests/Xi/Sms/Tests/Gateway/InfobipGatewayTest.php
+++ b/tests/Xi/Sms/Tests/Gateway/InfobipGatewayTest.php
@@ -3,37 +3,24 @@
 namespace Xi\Sms\Tests\Gateway;
 
 use Xi\Sms\Gateway\InfobipGateway;
+use Xi\Sms\SmsMessage;
 
 class InfobipGatewayTest extends \PHPUnit_Framework_TestCase
 {
+
+    use HttpRequestGatewayTestTrait;
+
     /**
      * @test
      */
     public function sendsCorrectlyFormattedXmlToRightPlace()
     {
+        $client = $this->createMockClient($historyContainer);
+
         $gateway = new InfobipGateway('lussuta', 'tussia', 'http://dr-kobros.com/api');
+        $gateway->setClient($client);
 
-        $browser = $this->getMockBuilder('Buzz\Browser')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $gateway->setClient($browser);
-
-        $xml =
-            "XML=<SMS><authentication><username>lussuta</username><password>tussia</password>" .
-            "</authentication><message>" .
-            "<sender>Losoposki</sender><datacoding>3</datacoding><text>Tehdaan sovinto, pojat.</text></message>" .
-            "<recipients><gsm>358503028030</gsm><gsm>358407682810</gsm></recipients></SMS>\n";
-
-        $browser
-            ->expects($this->once())->method('post')
-            ->with(
-                'http://dr-kobros.com/api/v3/sendsms/xml',
-                array(),
-                $xml
-            );
-
-        $message = new \Xi\Sms\SmsMessage(
+        $message = new SmsMessage(
             'Tehdaan sovinto, pojat.',
             'Losoposki',
             '358503028030'
@@ -43,5 +30,18 @@ class InfobipGatewayTest extends \PHPUnit_Framework_TestCase
 
         $ret = $gateway->send($message);
         $this->assertTrue($ret);
+
+        $this->assertCount(1, $historyContainer);
+        $transaction = $historyContainer[0];
+        $expectedUri = 'http://dr-kobros.com/api/v3/sendsms/xml';
+        $xml =
+            "XML=<SMS><authentication><username>lussuta</username><password>tussia</password>" .
+            "</authentication><message>" .
+            "<sender>Losoposki</sender><datacoding>3</datacoding><text>Tehdaan sovinto, pojat.</text></message>" .
+            "<recipients><gsm>358503028030</gsm><gsm>358407682810</gsm></recipients></SMS>\n";
+
+        $this->assertSame('POST', $transaction['request']->getMethod());
+        $this->assertSame($expectedUri, (string) $transaction['request']->getUri());
+        $this->assertSame($xml, (string) $transaction['request']->getBody());
     }
 }

--- a/tests/Xi/Sms/Tests/Gateway/InfobipGatewayTest.php
+++ b/tests/Xi/Sms/Tests/Gateway/InfobipGatewayTest.php
@@ -2,6 +2,7 @@
 
 namespace Xi\Sms\Tests\Gateway;
 
+use GuzzleHttp\Psr7\Response;
 use Xi\Sms\Gateway\InfobipGateway;
 use Xi\Sms\SmsMessage;
 
@@ -13,11 +14,11 @@ class InfobipGatewayTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function sendsCorrectlyFormattedXmlToRightPlace()
+    public function sendsSingleMessage()
     {
         $client = $this->createMockClient($historyContainer);
 
-        $gateway = new InfobipGateway('lussuta', 'tussia', 'http://dr-kobros.com/api');
+        $gateway = new InfobipGateway('lussuta', 'tussia');
         $gateway->setClient($client);
 
         $message = new SmsMessage(
@@ -26,22 +27,73 @@ class InfobipGatewayTest extends \PHPUnit_Framework_TestCase
             '358503028030'
         );
 
-        $message->addTo('358407682810');
+        $ret = $gateway->send($message);
+        $this->assertTrue($ret);
+
+        $this->assertCount(1, $historyContainer);
+        $transaction = $historyContainer[0];
+        $expectedUri = 'https://api.infobip.com/sms/1/text/single';
+        $this->assertSame('POST', $transaction['request']->getMethod());
+        $this->assertSame($expectedUri, (string) $transaction['request']->getUri());
+
+        $requestBody = (string) $transaction['request']->getBody();
+        $requestJson = json_decode($requestBody, true);
+
+        $this->assertArrayHasKey('from', $requestJson);
+        $this->assertArrayHasKey('to', $requestJson);
+        $this->assertArrayHasKey('text', $requestJson);
+        $this->assertEquals('Losoposki', $requestJson['from']);
+        $this->assertContains('358503028030', $requestJson['to']);
+        $this->assertEquals('Tehdaan sovinto, pojat.', $requestJson['text']);
+    }
+
+    /**
+     * @test
+     */
+    public function sendsMultipleMessages()
+    {
+        $client = $this->createMockClient($historyContainer);
+
+        $gateway = new InfobipGateway('lussuta', 'tussia');
+        $gateway->setClient($client);
+
+        $message = new SmsMessage(
+            'Tehdaan sovinto, pojat.',
+            'Losoposki',
+            ['358503028030', '358441234567']
+        );
 
         $ret = $gateway->send($message);
         $this->assertTrue($ret);
 
         $this->assertCount(1, $historyContainer);
         $transaction = $historyContainer[0];
-        $expectedUri = 'http://dr-kobros.com/api/v3/sendsms/xml';
-        $xml =
-            "XML=<SMS><authentication><username>lussuta</username><password>tussia</password>" .
-            "</authentication><message>" .
-            "<sender>Losoposki</sender><datacoding>3</datacoding><text>Tehdaan sovinto, pojat.</text></message>" .
-            "<recipients><gsm>358503028030</gsm><gsm>358407682810</gsm></recipients></SMS>\n";
 
-        $this->assertSame('POST', $transaction['request']->getMethod());
-        $this->assertSame($expectedUri, (string) $transaction['request']->getUri());
-        $this->assertSame($xml, (string) $transaction['request']->getBody());
+        $requestBody = (string) $transaction['request']->getBody();
+        $requestJson = json_decode($requestBody, true);
+
+        $this->assertArrayHasKey('to', $requestJson);
+        $this->assertContains('358503028030', $requestJson['to']);
+        $this->assertContains('358441234567', $requestJson['to']);
+    }
+
+    /**
+     * @test
+     */
+    public function httpErrorResultsInFailure()
+    {
+        $client = $this->createMockClient($historyContainer, new Response(404));
+
+        $gateway = new InfobipGateway('lussuta', 'tussia');
+        $gateway->setClient($client);
+
+        $message = new SmsMessage(
+            'Tehdaan sovinto, pojat.',
+            'Losoposki',
+            '358503028030'
+        );
+
+        $ret = $gateway->send($message);
+        $this->assertFalse($ret);
     }
 }

--- a/tests/Xi/Sms/Tests/Gateway/Legacy/LegacyMessageBirdGatewayTest.php
+++ b/tests/Xi/Sms/Tests/Gateway/Legacy/LegacyMessageBirdGatewayTest.php
@@ -4,30 +4,26 @@ namespace Xi\Sms\Tests\Gateway\Legacy;
 
 use Xi\Sms\Gateway\Legacy\MessageBirdGateway;
 use Xi\Sms\SmsMessage;
+use Xi\Sms\Tests\Gateway\HttpRequestGatewayTestTrait;
 
 class LegacyMessageBirdGatewayTest extends \PHPUnit_Framework_TestCase
 {
+
+    use HttpRequestGatewayTestTrait;
+
     /**
      * @test
      */
     public function sends()
     {
+        $client = $this->createMockClient($historyContainer);
 
         $browser = $this->getMockBuilder('Buzz\Browser')
             ->disableOriginalConstructor()
             ->getMock();
 
-        $browser
-            ->expects($this->once())
-            ->method('post')
-            ->with(
-                'https://api.messagebird.com/xml/sms?gateway=1&username=username&password=password&originator=Tietoisku&recipients=3581234567&type=normal&message=Tenhunen+lipaisee',
-                array()
-            );
-
         $gateway = new MessageBirdGateway('username', 'password');
-
-        $gateway->setClient($browser);
+        $gateway->setClient($client);
 
         $message = new SmsMessage(
             'Tenhunen lipaisee',
@@ -37,5 +33,12 @@ class LegacyMessageBirdGatewayTest extends \PHPUnit_Framework_TestCase
 
         $ret = $gateway->send($message);
         $this->assertTrue($ret);
+
+        $this->assertCount(1, $historyContainer);
+        $transaction = $historyContainer[0];
+        $expectedUri = 'https://api.messagebird.com/xml/sms?gateway=1&username=username&password=password&originator=Tietoisku&recipients=3581234567&type=normal&message=Tenhunen+lipaisee';
+
+        $this->assertSame('POST', $transaction['request']->getMethod());
+        $this->assertSame($expectedUri, (string) $transaction['request']->getUri());
     }
 }

--- a/tests/Xi/Sms/Tests/Gateway/PixieGatewayTest.php
+++ b/tests/Xi/Sms/Tests/Gateway/PixieGatewayTest.php
@@ -16,7 +16,7 @@ class PixieGatewayTest extends \PHPUnit_Framework_TestCase
     {
         $response = new Response(
             200,
-            array(),
+            [],
             '<?xml version="1.0" encoding = "ISO-8859-1" ?>'.
                 '<response code="0"><cost>50</cost>'.
             '</response>'
@@ -28,7 +28,7 @@ class PixieGatewayTest extends \PHPUnit_Framework_TestCase
     {
         $response = new Response(
             200,
-            array(),
+            [],
             '<?xml version="1.0" encoding = "ISO-8859-1" ?>'.
                 '<response code="'.$code.'" description="'.$message.'">'.
             '</response>'
@@ -40,7 +40,7 @@ class PixieGatewayTest extends \PHPUnit_Framework_TestCase
     {
         $response = new Response(
             200,
-            array(),
+            [],
             '<?not_valid_xml<'
         );
         return $response;
@@ -65,7 +65,7 @@ class PixieGatewayTest extends \PHPUnit_Framework_TestCase
         $message = new SmsMessage(
             'Hello world',
             'Santa Claus',
-            array(12345678)
+            [12345678]
         );
 
         $result = $gateway->send($message);
@@ -85,7 +85,7 @@ class PixieGatewayTest extends \PHPUnit_Framework_TestCase
         $message = new SmsMessage(
             'Rea i morgon. Välkommen',
             'Butiken',
-            array(4670234567,463849235)
+            [4670234567,463849235]
         );
 
         $gateway->sendOrThrowException($message);
@@ -112,7 +112,7 @@ class PixieGatewayTest extends \PHPUnit_Framework_TestCase
         $message = new SmsMessage(
             'Nice message',
             'Very long sender name',
-            array(12345678)
+            [12345678]
         );
 
         $this->setExpectedException('\Xi\Sms\RuntimeException');
@@ -136,7 +136,7 @@ class PixieGatewayTest extends \PHPUnit_Framework_TestCase
         $message = new SmsMessage(
             'Nice message',
             'Me',
-            array(12345678)
+            [12345678]
         );
 
         $this->setExpectedException('Xi\Sms\RuntimeException');

--- a/tests/Xi/Sms/Tests/Gateway/SmskaufenGatewayTest.php
+++ b/tests/Xi/Sms/Tests/Gateway/SmskaufenGatewayTest.php
@@ -27,12 +27,12 @@ class SmskaufenGatewayTest extends \PHPUnit_Framework_TestCase
 
     private function getMockedGateway(Client $client, $gateway, $https = true)
     {
-        $SmskaufenGateway = new SmskaufenGateway(array(
+        $SmskaufenGateway = new SmskaufenGateway([
             'username' => 'XXX',
             'password' => 'YYY',
             'gateway' => $gateway,
             'https' => $https
-        ));
+        ]);
         $SmskaufenGateway->setClient($client);
         return $SmskaufenGateway;
     }
@@ -45,7 +45,7 @@ class SmskaufenGatewayTest extends \PHPUnit_Framework_TestCase
         $client = $this->createMockClient();
         $gateway = $this->getMockedGateway($client, 13);
 
-        $msg = new SmsMessage('Hi', '00491234', array('00491111', '015111111', '0170111111'));
+        $msg = new SmsMessage('Hi', '00491234', ['00491111', '015111111', '0170111111']);
         $this->setExpectedException('Xi\Sms\RuntimeException');
         $gateway->send($msg);
     }
@@ -59,7 +59,7 @@ class SmskaufenGatewayTest extends \PHPUnit_Framework_TestCase
         $client = $this->createMockClient($historyContainer, $response);
         $gateway = $this->getMockedGateway($client, 4);
 
-        $msg = new SmsMessage('Hi', '00491234', array('00491111', '015111111', '0170111111'));
+        $msg = new SmsMessage('Hi', '00491234', ['00491111', '015111111', '0170111111']);
         $response = $gateway->send($msg); // Should not throw any exception
         $this->assertFalse($response);
     }
@@ -109,7 +109,7 @@ class SmskaufenGatewayTest extends \PHPUnit_Framework_TestCase
      */
     public function sendFail2()
     {
-        $response = new Response(200, array(), '121');
+        $response = new Response(200, [], '121');
         $client = $this->createMockClient($historyContainer, $response);
         $gateway = $this->getMockedGateway($client, 4);
 
@@ -137,7 +137,7 @@ class SmskaufenGatewayTest extends \PHPUnit_Framework_TestCase
      */
     public function sendSuccess()
     {
-        $response = new Response(200, array(), '100');
+        $response = new Response(200, [], '100');
         $client = $this->createMockClient($historyContainer, $response);
         $gateway = $this->getMockedGateway($client, 4);
 
@@ -151,11 +151,11 @@ class SmskaufenGatewayTest extends \PHPUnit_Framework_TestCase
      */
     public function urlMassDispatch()
     {
-        $response = new Response(200, array(), '100');
+        $response = new Response(200, [], '100');
         $client = $this->createMockClient($historyContainer, $response);
         $gateway = $this->getMockedGateway($client, 4, false);
 
-        $msg = new SmsMessage('Hi', '00491234', array('00491111', '015111111', '0170111111'));
+        $msg = new SmsMessage('Hi', '00491234', ['00491111', '015111111', '0170111111']);
         $success = $gateway->send($msg);
         $this->assertTrue($success);
 
@@ -184,7 +184,7 @@ class SmskaufenGatewayTest extends \PHPUnit_Framework_TestCase
      */
     public function urlNormalDispatch()
     {
-        $response = new Response(200, array(), '100');
+        $response = new Response(200, [], '100');
         $client = $this->createMockClient($historyContainer, $response);
         $gateway = $this->getMockedGateway($client, 4);
 

--- a/tests/Xi/Sms/Tests/SmsMessageTest.php
+++ b/tests/Xi/Sms/Tests/SmsMessageTest.php
@@ -15,7 +15,7 @@ class SmsMessageTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame('Tussi', $message->getBody());
         $this->assertSame('Lussutaja', $message->getFrom());
-        $this->assertSame(array('358503028030'), $message->getTo());
+        $this->assertSame(['358503028030'], $message->getTo());
     }
 
     /**
@@ -29,7 +29,7 @@ class SmsMessageTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(0, $message->getTo());
 
         $this->assertSame($message, $message->addTo('12345'));
-        $this->assertSame(array('12345'), $message->getTo());
+        $this->assertSame(['12345'], $message->getTo());
     }
 
     /**
@@ -46,9 +46,9 @@ class SmsMessageTest extends \PHPUnit_Framework_TestCase
             ]
         );
 
-        $this->assertSame(array('358503028030'), $message->getTo());
+        $this->assertSame(['358503028030'], $message->getTo());
 
         $message->addTo('358503028030');
-        $this->assertSame(array('358503028030'), $message->getTo());
+        $this->assertSame(['358503028030'], $message->getTo());
     }
 }


### PR DESCRIPTION
Buzz 0.17 broke backwards compatibility and would have required either a version constraint or code to be updated to match. Here instead code is updated to use Guzzle which has some cool features and is more widely used.

- use Guzzle HTTP client instead of Buzz
- updated tests to match and make use of Guzzle mock handler
- removed carriage returns in some files and fixed formatting
- updated Infobip gateway to use newer JSON API

All tests pass. Sending an actual message was only tested using InfobipGateway.